### PR TITLE
Changed the verbosity function to public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,8 @@ impl<L: LogLevel> Verbosity<L> {
         self.log_level().is_none()
     }
 
-    fn verbosity(&self) -> i8 {
+    // The raw i8 value of the combined verbosity level
+    pub fn verbosity(&self) -> i8 {
         level_value(L::default()) - (self.quiet as i8) + (self.verbose as i8)
     }
 }


### PR DESCRIPTION
Changing the `verbosity()` function to public allows the user to retrieve the raw i8 value of the flag calculation.

The use case:
Users that use other logging libraries, such as tracing, can now use this library to retrieve the integer value to create their own mapping without doing a redundant and lossy type conversion from `Log::Filter` back to `i8`.

Fixes #53
