### PR TITLE
fix(deps): Wording in "Process" section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ to re-work some of it and the discouragement that goes along with that.
 
 When you first post a PR, we request that the commit history get cleaned
 up.  We recommend avoiding this during the PR to make it easier to review how
-feedback was handled. Once the commit is ready, we'll ask you to clean up the
+feedback was handled. Once the PR is ready, we'll ask you to clean up the
 commit history.  Once you let us know this is done, we can move forward with
 merging!  If you are uncomfortable with these parts of git, let us know and we
 can help.


### PR DESCRIPTION
`"Once the PR is ready, we'll ask you to clean up the commit history."`

Please close without further explanations if I misunderstood the sentence.
The entire sentence might also be considered duplicate and be removed.
Probably `"When you first post a PR, we request that the commit history get cleaned
up.  We recommend avoiding this during the PR to make it easier to review how
feedback was handled."` is enough.