### PR TITLE
feat: Add serde feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "serde",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -283,6 +284,26 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,13 @@ codecov = { repository = "clap-rs/clap-verbosity-flag" }
 [dependencies]
 log = "0.4.1"
 clap = { version = "4.0.0", default-features = false, features = ["std", "derive"] }
+serde = { version = "1.0.26", features = ["derive"], optional = true }
 
 [dev-dependencies]
 env_logger = "0.10.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-log = "0.1"
+
+[features]
+serde = ["dep:serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,7 @@
 pub use log::Level;
 pub use log::LevelFilter;
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(clap::Args, Debug, Clone)]
 pub struct Verbosity<L: LogLevel = ErrorLevel> {
     #[arg(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,10 @@
 pub use log::Level;
 pub use log::LevelFilter;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(clap::Args, Debug, Clone)]
 pub struct Verbosity<L: LogLevel = ErrorLevel> {
     #[arg(
@@ -83,6 +87,7 @@ pub struct Verbosity<L: LogLevel = ErrorLevel> {
     )]
     quiet: u8,
 
+    #[cfg_attr(feature = "serde", serde(skip))]
     #[arg(skip)]
     phantom: std::marker::PhantomData<L>,
 }


### PR DESCRIPTION
Optionally allow verbosity flag to be serialized with serde.

Useful for when you want to easily save and load a configuration.