### PR TITLE
Make Verbosity implement Default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 pub use log::Level;
 pub use log::LevelFilter;
 
-#[derive(clap::Args, Debug, Clone)]
+#[derive(clap::Args, Debug, Clone, Default)]
 pub struct Verbosity<L: LogLevel = ErrorLevel> {
     #[arg(
         long,


### PR DESCRIPTION
This simplified the unit tests of a new feature that I'm adding to cargo-semver-checks. And [it's also generally considered good practice to implement those traits if you can](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits).