### PR TITLE
fix: remove comment that shows up in clap help text

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@
 pub use log::Level;
 pub use log::LevelFilter;
 
-/// Logging flags to `#[command(flatten)]` into your CLI
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct Verbosity<L: LogLevel = ErrorLevel> {
     #[arg(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,9 @@
 pub use log::Level;
 pub use log::LevelFilter;
 
+/// Logging flags to `#[command(flatten)]` into your CLI
 #[derive(clap::Args, Debug, Clone, Default)]
+#[command(about = None, long_about = None)]
 pub struct Verbosity<L: LogLevel = ErrorLevel> {
     #[arg(
         long,


### PR DESCRIPTION
fixes #85 