### PR TITLE
make tracing supported as first-class citizen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]
+        logger: ["log", "tracing"]
     continue-on-error: ${{ matrix.rust != 'stable' }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,15 +42,16 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
     - name: Build
-      run: cargo test --no-run --workspace --all-features
+      run: cargo test --no-run --workspace --no-default-features --features ${{ matrix.logger }}
     - name: Default features
       run: cargo test --workspace
-    - name: All features
-      run: cargo test --workspace --all-features
-    - name: No-default features
-      run: cargo test --workspace --no-default-features
+    - name: Feature ${{ matrix.logger }}
+      run: cargo test --workspace --no-default-features --features ${{ matrix.logger }}
   msrv:
     name: "Check MSRV: 1.70"
+    strategy:
+      matrix:
+        logger: ["log", "tracing"]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -61,10 +63,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Default features
       run: cargo check --workspace --all-targets
-    - name: All features
-      run: cargo check --workspace --all-targets --all-features
-    - name: No-default features
-      run: cargo check --workspace --all-targets --no-default-features
+    - name: Feature ${{ matrix.logger }}
+      run: cargo check --workspace --all-targets --no-default-features --features ${{ matrix.logger }}
   lockfile:
     runs-on: ubuntu-latest
     steps:
@@ -91,7 +91,7 @@ jobs:
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings
-      run: cargo doc --workspace --all-features --no-deps --document-private-items
+      run: cargo doc --workspace --no-deps --document-private-items
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest
@@ -111,6 +111,9 @@ jobs:
   clippy:
     name: clippy
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        logger: ["log", "tracing"]
     permissions:
       security-events: write # to upload sarif results
     steps:
@@ -128,7 +131,7 @@ jobs:
       run: cargo install sarif-fmt --version 0.3.4 --locked # Held back due to msrv
     - name: Check
       run: >
-        cargo clippy --workspace --all-features --all-targets --message-format=json -- -D warnings --allow deprecated
+        cargo clippy --workspace --no-default-features --features ${{ matrix.logger }} --all-targets --message-format=json -- -D warnings --allow deprecated
         | clippy-sarif
         | tee clippy-results.sarif
         | sarif-fmt
@@ -139,4 +142,4 @@ jobs:
         sarif_file: clippy-results.sarif
         wait-for-processing: true
     - name: Report status
-      run: cargo clippy --workspace --all-features --all-targets -- -D warnings --allow deprecated
+      run: cargo clippy --workspace --no-default-features --features ${{ matrix.logger }} --all-targets -- -D warnings --allow deprecated

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable", "beta"]
+        logger: ["log", "tracing"]
         include:
         - os: ubuntu-latest
           rust: "nightly"
@@ -34,12 +35,13 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Default features
       run: cargo test --workspace
-    - name: All features
-      run: cargo test --workspace --all-features
-    - name: No-default features
-      run: cargo test --workspace --no-default-features
+    - name: Features ${{ matrix.logger }}
+      run: cargo test --workspace --no-default-features --features ${{ matrix.logger }}
   latest:
     name: "Check latest dependencies"
+    strategy:
+      matrix:
+        logger: ["log", "tracing"]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -53,7 +55,5 @@ jobs:
       run: cargo update
     - name: Default features
       run: cargo test --workspace --all-targets
-    - name: All features
-      run: cargo test --workspace --all-targets --all-features
-    - name: No-default features
-      run: cargo test --workspace --all-targets --no-default-features
+    - name: Feature ${{ matrix.logger }}
+      run: cargo test --workspace --all-targets --no-default-features --features ${{ matrix.logger }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 include.workspace = true
 
 [package.metadata.docs.rs]
-all-features = true
+all-features = false
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.release]
@@ -45,12 +45,15 @@ pre-release-replacements = [
 codecov = { repository = "clap-rs/clap-verbosity-flag" }
 
 [dependencies]
-log = "0.4.1"
+log = { version = "0.4.1", optional = true }
+tracing = { version = "0.1", optional = true }
 clap = { version = "4.0.0", default-features = false, features = ["std", "derive"] }
 
 [dev-dependencies]
 clap = { version = "4.4.12", default-features = false, features = ["help", "usage"] }
 env_logger = "0.10.1"
-tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-log = "0.2"
+
+[features]
+default = ["log"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# clap-verbosity-flag for `log`
+# clap-verbosity-flag for `log`/`tracing`
 
 [![Documentation](https://img.shields.io/badge/docs-master-blue.svg)][Documentation]
 ![License](https://img.shields.io/crates/l/clap-verbosity-flag.svg)

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,3 +1,4 @@
+
 use clap::Parser;
 use clap_verbosity_flag::Verbosity;
 
@@ -8,6 +9,7 @@ struct Cli {
     verbose: Verbosity,
 }
 
+#[cfg(feature = "log")]
 fn main() {
     let cli = Cli::parse();
 
@@ -21,3 +23,6 @@ fn main() {
     log::debug!("Engine temperature is 200 degrees");
     log::trace!("Engine subsection is 300 degrees");
 }
+
+#[cfg(not(feature = "log"))]
+fn main() {}

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -1,6 +1,6 @@
+
 use clap::Parser;
 use clap_verbosity_flag::Verbosity;
-use tracing_log::AsTrace;
 
 /// Foo
 #[derive(Debug, Parser)]
@@ -9,11 +9,12 @@ struct Cli {
     verbose: Verbosity,
 }
 
+#[cfg(feature = "tracing")]
 fn main() {
     let cli = Cli::parse();
 
     tracing_subscriber::fmt()
-        .with_max_level(cli.verbose.log_level_filter().as_trace())
+        .with_max_level(cli.verbose.log_level_filter())
         .init();
 
     tracing::error!("Engines exploded");
@@ -22,3 +23,6 @@ fn main() {
     tracing::debug!("Engine temperature is 200 degrees");
     tracing::trace!("Engine subsection is 300 degrees");
 }
+
+#[cfg(not(feature = "tracing"))]
+fn main() {}


### PR DESCRIPTION
Although you could use it with tracing already, it still required the log crate as a dependency.
Not anymore :)