### PR TITLE
Use u8 for internal verbosity level calculation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,9 @@ impl<L: LogLevel> Verbosity<L> {
     }
 
     fn verbosity(&self) -> i8 {
-        level_value(L::default()) - (self.quiet as i8) + (self.verbose as i8)
+        let default_verbosity = level_value(L::default());
+        let verbosity = default_verbosity - (self.quiet as i8) + (self.verbose as i8);
+        verbosity
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,14 +126,14 @@ impl<L: LogLevel> Verbosity<L> {
         self.log_level().is_none()
     }
 
-    fn verbosity(&self) -> i8 {
+    fn verbosity(&self) -> u8 {
         let default_verbosity = level_value(L::default());
-        let verbosity = default_verbosity - (self.quiet as i8) + (self.verbose as i8);
-        verbosity
+        let verbosity = default_verbosity as i8 - (self.quiet as i8) + (self.verbose as i8);
+        verbosity as u8
     }
 }
 
-fn level_value(level: Option<Level>) -> i8 {
+fn level_value(level: Option<Level>) -> u8 {
     match level {
         None => 0,
         Some(Level::Error) => 1,
@@ -144,14 +144,14 @@ fn level_value(level: Option<Level>) -> i8 {
     }
 }
 
-fn level_enum(verbosity: i8) -> Option<Level> {
+fn level_enum(verbosity: u8) -> Option<Level> {
     match verbosity {
-        i8::MIN..=0 => None,
+        0 => None,
         1 => Some(Level::Error),
         2 => Some(Level::Warn),
         3 => Some(Level::Info),
         4 => Some(Level::Debug),
-        5..=i8::MAX => Some(Level::Trace),
+        5..=u8::MAX => Some(Level::Trace),
     }
 }
 
@@ -250,7 +250,7 @@ mod test {
             (5, 0, Some(Level::Trace), LevelFilter::Trace),
             (255, 0, None, LevelFilter::Off),
             (0, 1, None, LevelFilter::Off),
-            (0, 2, None, LevelFilter::Off),
+            (0, 2, Some(Level::Trace), LevelFilter::Trace),
             (0, 255, Some(Level::Warn), LevelFilter::Warn),
             (255, 255, Some(Level::Error), LevelFilter::Error),
         ];
@@ -282,7 +282,7 @@ mod test {
             (255, 0, Some(Level::Error), LevelFilter::Error),
             (0, 1, Some(Level::Error), LevelFilter::Error),
             (0, 2, None, LevelFilter::Off),
-            (0, 3, None, LevelFilter::Off),
+            (0, 3, Some(Level::Trace), LevelFilter::Trace),
             (0, 255, Some(Level::Info), LevelFilter::Info),
             (255, 255, Some(Level::Warn), LevelFilter::Warn),
         ];
@@ -314,7 +314,7 @@ mod test {
             (0, 1, Some(Level::Warn), LevelFilter::Warn),
             (0, 2, Some(Level::Error), LevelFilter::Error),
             (0, 3, None, LevelFilter::Off),
-            (0, 4, None, LevelFilter::Off),
+            (0, 4, Some(Level::Trace), LevelFilter::Trace),
             (0, 255, Some(Level::Debug), LevelFilter::Debug),
             (255, 255, Some(Level::Info), LevelFilter::Info),
         ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,23 +133,23 @@ impl<L: LogLevel> Verbosity<L> {
 
 fn level_value(level: Option<Level>) -> i8 {
     match level {
-        None => -1,
-        Some(Level::Error) => 0,
-        Some(Level::Warn) => 1,
-        Some(Level::Info) => 2,
-        Some(Level::Debug) => 3,
-        Some(Level::Trace) => 4,
+        None => 0,
+        Some(Level::Error) => 1,
+        Some(Level::Warn) => 2,
+        Some(Level::Info) => 3,
+        Some(Level::Debug) => 4,
+        Some(Level::Trace) => 5,
     }
 }
 
 fn level_enum(verbosity: i8) -> Option<Level> {
     match verbosity {
-        i8::MIN..=-1 => None,
-        0 => Some(Level::Error),
-        1 => Some(Level::Warn),
-        2 => Some(Level::Info),
-        3 => Some(Level::Debug),
-        4..=i8::MAX => Some(Level::Trace),
+        i8::MIN..=0 => None,
+        1 => Some(Level::Error),
+        2 => Some(Level::Warn),
+        3 => Some(Level::Info),
+        4 => Some(Level::Debug),
+        5..=i8::MAX => Some(Level::Trace),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,8 @@ impl<L: LogLevel> Verbosity<L> {
 
     fn verbosity(&self) -> u8 {
         let default_verbosity = level_value(L::default());
-        let verbosity = default_verbosity as i8 - (self.quiet as i8) + (self.verbose as i8);
-        verbosity as u8
+        let verbosity = default_verbosity as i16 - self.quiet as i16 + self.verbose as i16;
+        verbosity.clamp(0, u8::MAX as i16) as u8
     }
 }
 
@@ -248,10 +248,10 @@ mod test {
             (3, 0, Some(Level::Debug), LevelFilter::Debug),
             (4, 0, Some(Level::Trace), LevelFilter::Trace),
             (5, 0, Some(Level::Trace), LevelFilter::Trace),
-            (255, 0, None, LevelFilter::Off),
+            (255, 0, Some(Level::Trace), LevelFilter::Trace),
             (0, 1, None, LevelFilter::Off),
-            (0, 2, Some(Level::Trace), LevelFilter::Trace),
-            (0, 255, Some(Level::Warn), LevelFilter::Warn),
+            (0, 2, None, LevelFilter::Off),
+            (0, 255, None, LevelFilter::Off),
             (255, 255, Some(Level::Error), LevelFilter::Error),
         ];
 
@@ -279,11 +279,11 @@ mod test {
             (2, 0, Some(Level::Debug), LevelFilter::Debug),
             (3, 0, Some(Level::Trace), LevelFilter::Trace),
             (4, 0, Some(Level::Trace), LevelFilter::Trace),
-            (255, 0, Some(Level::Error), LevelFilter::Error),
+            (255, 0, Some(Level::Trace), LevelFilter::Trace),
             (0, 1, Some(Level::Error), LevelFilter::Error),
             (0, 2, None, LevelFilter::Off),
-            (0, 3, Some(Level::Trace), LevelFilter::Trace),
-            (0, 255, Some(Level::Info), LevelFilter::Info),
+            (0, 3, None, LevelFilter::Off),
+            (0, 255, None, LevelFilter::Off),
             (255, 255, Some(Level::Warn), LevelFilter::Warn),
         ];
 
@@ -310,12 +310,12 @@ mod test {
             (1, 0, Some(Level::Debug), LevelFilter::Debug),
             (2, 0, Some(Level::Trace), LevelFilter::Trace),
             (3, 0, Some(Level::Trace), LevelFilter::Trace),
-            (255, 0, Some(Level::Warn), LevelFilter::Warn),
+            (255, 0, Some(Level::Trace), LevelFilter::Trace),
             (0, 1, Some(Level::Warn), LevelFilter::Warn),
             (0, 2, Some(Level::Error), LevelFilter::Error),
             (0, 3, None, LevelFilter::Off),
-            (0, 4, Some(Level::Trace), LevelFilter::Trace),
-            (0, 255, Some(Level::Debug), LevelFilter::Debug),
+            (0, 4, None, LevelFilter::Off),
+            (0, 255, None, LevelFilter::Off),
             (255, 255, Some(Level::Info), LevelFilter::Info),
         ];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,4 +235,100 @@ mod test {
         use clap::CommandFactory;
         Cli::command().debug_assert();
     }
+
+    #[test]
+    fn verbosity_error_level() {
+        let tests = [
+            // verbose, quiet, expected_level, expected_filter
+            (0, 0, Some(Level::Error), LevelFilter::Error),
+            (1, 0, Some(Level::Warn), LevelFilter::Warn),
+            (2, 0, Some(Level::Info), LevelFilter::Info),
+            (3, 0, Some(Level::Debug), LevelFilter::Debug),
+            (4, 0, Some(Level::Trace), LevelFilter::Trace),
+            (5, 0, Some(Level::Trace), LevelFilter::Trace),
+            (255, 0, None, LevelFilter::Off),
+            (0, 1, None, LevelFilter::Off),
+            (0, 2, None, LevelFilter::Off),
+            (0, 255, Some(Level::Warn), LevelFilter::Warn),
+            (255, 255, Some(Level::Error), LevelFilter::Error),
+        ];
+
+        for (verbose, quiet, expected_level, expected_filter) in tests.iter() {
+            let v = Verbosity::<ErrorLevel>::new(*verbose, *quiet);
+            assert_eq!(
+                v.log_level(),
+                *expected_level,
+                "verbose = {verbose}, quiet = {quiet}"
+            );
+            assert_eq!(
+                v.log_level_filter(),
+                *expected_filter,
+                "verbose = {verbose}, quiet = {quiet}"
+            );
+        }
+    }
+
+    #[test]
+    fn verbosity_warn_level() {
+        let tests = [
+            // verbose, quiet, expected_level, expected_filter
+            (0, 0, Some(Level::Warn), LevelFilter::Warn),
+            (1, 0, Some(Level::Info), LevelFilter::Info),
+            (2, 0, Some(Level::Debug), LevelFilter::Debug),
+            (3, 0, Some(Level::Trace), LevelFilter::Trace),
+            (4, 0, Some(Level::Trace), LevelFilter::Trace),
+            (255, 0, Some(Level::Error), LevelFilter::Error),
+            (0, 1, Some(Level::Error), LevelFilter::Error),
+            (0, 2, None, LevelFilter::Off),
+            (0, 3, None, LevelFilter::Off),
+            (0, 255, Some(Level::Info), LevelFilter::Info),
+            (255, 255, Some(Level::Warn), LevelFilter::Warn),
+        ];
+
+        for (verbose, quiet, expected_level, expected_filter) in tests.iter() {
+            let v = Verbosity::<WarnLevel>::new(*verbose, *quiet);
+            assert_eq!(
+                v.log_level(),
+                *expected_level,
+                "verbose = {verbose}, quiet = {quiet}"
+            );
+            assert_eq!(
+                v.log_level_filter(),
+                *expected_filter,
+                "verbose = {verbose}, quiet = {quiet}"
+            );
+        }
+    }
+
+    #[test]
+    fn verbosity_info_level() {
+        let tests = [
+            // verbose, quiet, expected_level, expected_filter
+            (0, 0, Some(Level::Info), LevelFilter::Info),
+            (1, 0, Some(Level::Debug), LevelFilter::Debug),
+            (2, 0, Some(Level::Trace), LevelFilter::Trace),
+            (3, 0, Some(Level::Trace), LevelFilter::Trace),
+            (255, 0, Some(Level::Warn), LevelFilter::Warn),
+            (0, 1, Some(Level::Warn), LevelFilter::Warn),
+            (0, 2, Some(Level::Error), LevelFilter::Error),
+            (0, 3, None, LevelFilter::Off),
+            (0, 4, None, LevelFilter::Off),
+            (0, 255, Some(Level::Debug), LevelFilter::Debug),
+            (255, 255, Some(Level::Info), LevelFilter::Info),
+        ];
+
+        for (verbose, quiet, expected_level, expected_filter) in tests.iter() {
+            let v = Verbosity::<InfoLevel>::new(*verbose, *quiet);
+            assert_eq!(
+                v.log_level(),
+                *expected_level,
+                "verbose = {verbose}, quiet = {quiet}"
+            );
+            assert_eq!(
+                v.log_level_filter(),
+                *expected_filter,
+                "verbose = {verbose}, quiet = {quiet}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
This avoids integer overflow / underflow errors when calculating the
verbosity level. Prior to this change, constructing a `Verbosity` with
either parameter equal to `u8::MAX` would result in incorrect verbosity
level calculation.

This change adds tests to ensure that the verbosity level is correctly
calculated for each log level. These were run before and after the
change to ensure that the change is correct. The tests using 255 as
either input value were failing before the change and passing after the
change.

---

Addresses comments left in #114:
- https://github.com/clap-rs/clap-verbosity-flag/pull/114#discussion_r1768714565
- https://github.com/clap-rs/clap-verbosity-flag/pull/114#discussion_r1768718359

I pulled this out to a separate PR to make it easier to just address the points made in this change. I hope that's not too much of a burden.