### PR TITLE
feat!: Gate log crate behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,12 @@ pre-release-replacements = [
 [badges]
 codecov = { repository = "clap-rs/clap-verbosity-flag" }
 
+[features]
+default = ["log"]
+log = ["dep:log"]
+
 [dependencies]
-log = "0.4.1"
+log = { version = "0.4.1", optional = true }
 clap = { version = "4.0.0", default-features = false, features = ["std", "derive"] }
 
 [dev-dependencies]
@@ -126,3 +130,15 @@ tracing-log = "0.2"
 
 [lints]
 workspace = true
+
+[[example]]
+name = "log"
+required-features = ["log"]
+
+[[example]]
+name = "log_level"
+required-features = ["log"]
+
+[[example]]
+name = "tracing"
+required-features = ["log"]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,91 @@
+// These re-exports of the log crate make it easy to use this crate without having to depend on the
+// log crate directly. See <https://github.com/clap-rs/clap-verbosity-flag/issues/54> for more
+// information.
+pub use log::{Level, LevelFilter};
+
+use crate::VerbosityFilter;
+
+impl From<VerbosityFilter> for LevelFilter {
+    fn from(filter: VerbosityFilter) -> Self {
+        match filter {
+            VerbosityFilter::Off => LevelFilter::Off,
+            VerbosityFilter::Error => LevelFilter::Error,
+            VerbosityFilter::Warn => LevelFilter::Warn,
+            VerbosityFilter::Info => LevelFilter::Info,
+            VerbosityFilter::Debug => LevelFilter::Debug,
+            VerbosityFilter::Trace => LevelFilter::Trace,
+        }
+    }
+}
+
+impl From<LevelFilter> for VerbosityFilter {
+    fn from(level: LevelFilter) -> Self {
+        match level {
+            LevelFilter::Off => Self::Off,
+            LevelFilter::Error => Self::Error,
+            LevelFilter::Warn => Self::Warn,
+            LevelFilter::Info => Self::Info,
+            LevelFilter::Debug => Self::Debug,
+            LevelFilter::Trace => Self::Trace,
+        }
+    }
+}
+
+impl From<VerbosityFilter> for Option<Level> {
+    fn from(filter: VerbosityFilter) -> Self {
+        match filter {
+            VerbosityFilter::Off => None,
+            VerbosityFilter::Error => Some(Level::Error),
+            VerbosityFilter::Warn => Some(Level::Warn),
+            VerbosityFilter::Info => Some(Level::Info),
+            VerbosityFilter::Debug => Some(Level::Debug),
+            VerbosityFilter::Trace => Some(Level::Trace),
+        }
+    }
+}
+
+impl From<Option<Level>> for VerbosityFilter {
+    fn from(level: Option<Level>) -> Self {
+        match level {
+            None => Self::Off,
+            Some(Level::Error) => Self::Error,
+            Some(Level::Warn) => Self::Warn,
+            Some(Level::Info) => Self::Info,
+            Some(Level::Debug) => Self::Debug,
+            Some(Level::Trace) => Self::Trace,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DebugLevel, ErrorLevel, InfoLevel, OffLevel, TraceLevel, Verbosity, WarnLevel};
+
+    #[test]
+    fn log_level() {
+        let v = Verbosity::<OffLevel>::default();
+        assert_eq!(v.log_level(), None);
+        assert_eq!(v.log_level_filter(), LevelFilter::Off);
+
+        let v = Verbosity::<ErrorLevel>::default();
+        assert_eq!(v.log_level(), Some(Level::Error));
+        assert_eq!(v.log_level_filter(), LevelFilter::Error);
+
+        let v = Verbosity::<WarnLevel>::default();
+        assert_eq!(v.log_level(), Some(Level::Warn));
+        assert_eq!(v.log_level_filter(), LevelFilter::Warn);
+
+        let v = Verbosity::<InfoLevel>::default();
+        assert_eq!(v.log_level(), Some(Level::Info));
+        assert_eq!(v.log_level_filter(), LevelFilter::Info);
+
+        let v = Verbosity::<DebugLevel>::default();
+        assert_eq!(v.log_level(), Some(Level::Debug));
+        assert_eq!(v.log_level_filter(), LevelFilter::Debug);
+
+        let v = Verbosity::<TraceLevel>::default();
+        assert_eq!(v.log_level(), Some(Level::Trace));
+        assert_eq!(v.log_level_filter(), LevelFilter::Trace);
+    }
+}


### PR DESCRIPTION
- Add log feature flag (enabled by default)
- Move log specific code to `log` module
- Move top level re-exports of log types to `log` module

BREAKING CHANGE: The log crate is now an optional dependency, enabled by
default. The `log::Level` and `log::LevelFilter` types are now
re-exported from the `log` module rather than the crate root. If you
were using these types directly, you will need to update your imports.

```diff
-use clap_verbosity_flag::{Level, LevelFilter};
+use clap_verbosity_flag::log::{Level, LevelFilter};
```
