### PR TITLE
feat: Convert from &Verbosity to log / tracing

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -63,8 +63,20 @@ impl<L: LogLevel> From<Verbosity<L>> for LevelFilter {
     }
 }
 
+impl<L: LogLevel> From<&Verbosity<L>> for LevelFilter {
+    fn from(v: &Verbosity<L>) -> Self {
+        v.log_level_filter()
+    }
+}
+
 impl<L: LogLevel> From<Verbosity<L>> for Option<Level> {
     fn from(v: Verbosity<L>) -> Self {
+        v.log_level()
+    }
+}
+
+impl<L: LogLevel> From<&Verbosity<L>> for Option<Level> {
+    fn from(v: &Verbosity<L>) -> Self {
         v.log_level()
     }
 }
@@ -104,42 +116,54 @@ mod tests {
     #[test]
     fn into_opt_level() {
         let v = Verbosity::<OffLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), None);
         assert_eq!(Option::<Level>::from(v), None);
 
         let v = Verbosity::<ErrorLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::Error));
         assert_eq!(Option::<Level>::from(v), Some(Level::Error));
 
         let v = Verbosity::<WarnLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::Warn));
         assert_eq!(Option::<Level>::from(v), Some(Level::Warn));
 
         let v = Verbosity::<InfoLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::Info));
         assert_eq!(Option::<Level>::from(v), Some(Level::Info));
 
         let v = Verbosity::<DebugLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::Debug));
         assert_eq!(Option::<Level>::from(v), Some(Level::Debug));
 
         let v = Verbosity::<TraceLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::Trace));
         assert_eq!(Option::<Level>::from(v), Some(Level::Trace));
     }
 
     #[test]
     fn into_level_filter() {
         let v = Verbosity::<OffLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::Off);
         assert_eq!(LevelFilter::from(v), LevelFilter::Off);
 
         let v = Verbosity::<ErrorLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::Error);
         assert_eq!(LevelFilter::from(v), LevelFilter::Error);
 
         let v = Verbosity::<WarnLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::Warn);
         assert_eq!(LevelFilter::from(v), LevelFilter::Warn);
 
         let v = Verbosity::<InfoLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::Info);
         assert_eq!(LevelFilter::from(v), LevelFilter::Info);
 
         let v = Verbosity::<DebugLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::Debug);
         assert_eq!(LevelFilter::from(v), LevelFilter::Debug);
 
         let v = Verbosity::<TraceLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::Trace);
         assert_eq!(LevelFilter::from(v), LevelFilter::Trace);
     }
 }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -63,8 +63,20 @@ impl<L: LogLevel> From<Verbosity<L>> for LevelFilter {
     }
 }
 
+impl<L: LogLevel> From<&Verbosity<L>> for LevelFilter {
+    fn from(v: &Verbosity<L>) -> Self {
+        v.tracing_level_filter()
+    }
+}
+
 impl<L: LogLevel> From<Verbosity<L>> for Option<Level> {
     fn from(v: Verbosity<L>) -> Self {
+        v.tracing_level()
+    }
+}
+
+impl<L: LogLevel> From<&Verbosity<L>> for Option<Level> {
+    fn from(v: &Verbosity<L>) -> Self {
         v.tracing_level()
     }
 }
@@ -104,42 +116,54 @@ mod tests {
     #[test]
     fn into_opt_level() {
         let v = Verbosity::<OffLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), None);
         assert_eq!(Option::<Level>::from(v), None);
 
         let v = Verbosity::<ErrorLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::ERROR));
         assert_eq!(Option::<Level>::from(v), Some(Level::ERROR));
 
         let v = Verbosity::<WarnLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::WARN));
         assert_eq!(Option::<Level>::from(v), Some(Level::WARN));
 
         let v = Verbosity::<InfoLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::INFO));
         assert_eq!(Option::<Level>::from(v), Some(Level::INFO));
 
         let v = Verbosity::<DebugLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::DEBUG));
         assert_eq!(Option::<Level>::from(v), Some(Level::DEBUG));
 
         let v = Verbosity::<TraceLevel>::default();
+        assert_eq!(Option::<Level>::from(&v), Some(Level::TRACE));
         assert_eq!(Option::<Level>::from(v), Some(Level::TRACE));
     }
 
     #[test]
     fn into_level_filter() {
         let v = Verbosity::<OffLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::OFF);
         assert_eq!(LevelFilter::from(v), LevelFilter::OFF);
 
         let v = Verbosity::<ErrorLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::ERROR);
         assert_eq!(LevelFilter::from(v), LevelFilter::ERROR);
 
         let v = Verbosity::<WarnLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::WARN);
         assert_eq!(LevelFilter::from(v), LevelFilter::WARN);
 
         let v = Verbosity::<InfoLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::INFO);
         assert_eq!(LevelFilter::from(v), LevelFilter::INFO);
 
         let v = Verbosity::<DebugLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::DEBUG);
         assert_eq!(LevelFilter::from(v), LevelFilter::DEBUG);
 
         let v = Verbosity::<TraceLevel>::default();
+        assert_eq!(LevelFilter::from(&v), LevelFilter::TRACE);
         assert_eq!(LevelFilter::from(v), LevelFilter::TRACE);
     }
 }


### PR DESCRIPTION
This makes it possible to use a parsed args instance after using the
verbosity. E.g.:

```rust
let cli = Cli.parse();
tracing_subscriber::fmt()
    .with_max_level(&cli.verbosity)
    .init();
let foo = cli.some_other_arg;

// or
env_logger::Builder::new()
    .filter_level((&cli.verbosity).into())
    .init();
let foo = cli.some_other_arg;
```